### PR TITLE
Fix to allow equal min and max range values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ npm-debug.log
 .zuulrc
 .nyc_output
 .DS_Store
+.idea

--- a/src/part.js
+++ b/src/part.js
@@ -160,7 +160,7 @@ Part.prototype.parseRange = function(range, context) {
   } else if (subparts.length === 2) {
     var minValue = parseInt(subparts[0], 10);
     var maxValue = parseInt(subparts[1], 10);
-    if (maxValue <= minValue) {
+    if (maxValue < minValue) {
       this.throw(
         'Max range is less than min range in "%s"',
         range

--- a/test/cron.outputStrings.js
+++ b/test/cron.outputStrings.js
@@ -37,3 +37,12 @@ test('Should not output month names in step', function(t) {
   t.plan(1);
   t.equal(cron.toString(), '* * * */2 1-5');
 });
+test('Should output correct string when min and max range values are the same',
+  function(t) {
+    var cron = new Cron({
+      outputWeekdayNames: true
+    });
+    t.plan(1);
+    cron.fromString('* * * * 1-1');
+    t.equal(cron.toString(), '* * * * MON');
+  });

--- a/test/range.valid.js
+++ b/test/range.valid.js
@@ -104,7 +104,14 @@ var validRanges = [
     output: '5-7',
     min: 0,
     max: 59
-  }
+  },
+  {
+    input: '1-1',
+    arr: [1],
+    output: '1',
+    min: 1,
+    max: 5
+  },
 ];
 test('Should parse valid string', function(t) {
   t.plan(validRanges.length * 2);

--- a/test/schedule.valid.js
+++ b/test/schedule.valid.js
@@ -75,6 +75,12 @@ var schedules = [
     prev: '2013-02-08T09:20:00.000Z',
     now: '2013-02-08T09:30:00.000Z',
     next: '2013-02-08T09:30:00.000Z'
+  },
+  {
+    schedule: '* 6 * * 1-1',
+    prev: '2013-02-04T06:59:00.000Z',
+    now: '2013-02-08T09:32:15.000Z',
+    next: '2013-02-11T06:00:00.000Z'
   }
 ];
 test('Should output execution time for valid schedule', function(t) {


### PR DESCRIPTION
### Description

The range check incorrectly throws the message "Max range is less than min range" when max range and min range values are equal. Example of a cron string: '0 6 * * 1-1' . Such cron strings are valid and are correctly handled by other cron converters online.

Changing `if (maxValue <= minValue)` to `if (maxValue < minValue)` fixes the above issue. This `<=` condition may have been a coding error in the past since the check clearly does not match the corresponding error message being thrown - "Max range is less than min range"

I have added a few unit tests for this fix. And I have also verified that this change fixes the issue we were having in our web application when handling cron strings with the same min and max range value.