### PR TITLE
Allow "L" for end of the month in the "day" field of cron

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { arrayToStringPart, stringToArrayPart } from "./part.js";
 import { assertValidArray } from "./util.js";
-import { Options } from "./types.js";
+import { Options, ParseOptions } from "./types.js";
 import { Schedule } from "./schedule.js";
 import { units } from "./units.js";
 export { Schedule } from "./schedule.js";
@@ -12,13 +12,19 @@ const defaultOptions: Options = {
   outputWeekdayNames: false,
 };
 
+
+const defaultParseOptions: ParseOptions = {
+  enableLastDayOfMonth: true
+};
+
 /**
  * Parses a cron string
  *
  * @param str The string to parse
+ * @param options Parse options
  * @return The cron schedule as an array
  */
-export function stringToArray(str: string) {
+export function stringToArray(str: string, options?: Partial<ParseOptions>) {
   if (typeof str !== "string") {
     throw new Error("Invalid cron string");
   }
@@ -26,7 +32,7 @@ export function stringToArray(str: string) {
   if (parts.length !== 5) {
     throw new Error("Invalid cron string format");
   } else {
-    return parts.map((str, idx) => stringToArrayPart(str, units[idx]));
+    return parts.map((str, idx) => stringToArrayPart(str, units[idx], { ...defaultParseOptions, ...options }));
   }
 };
 

--- a/src/part.ts
+++ b/src/part.ts
@@ -1,4 +1,4 @@
-import { Options, Unit } from "./types.js";
+import { Options, ParseOptions, Unit } from "./types.js";
 import { dedup, flatten, parseNumber, range, sort } from "./util.js";
 
 /**
@@ -18,7 +18,7 @@ export const arrayToStringPart = (
     dedup(
       fixSunday(
         arr.map((value) => {
-          const parsedValue = parseNumber(unit, value);
+          const parsedValue = parseNumber(unit, value, {enableLastDayOfMonth: false});
           if (parsedValue === undefined) {
             throw getError(`Invalid value "${value}"`, unit);
           }
@@ -40,9 +40,10 @@ export const arrayToStringPart = (
  *
  * @param str The part of a cron string to convert
  * @param unit The unit for the part
+ * @param options Parse options
  * @return An array of numbers
  */
-export const stringToArrayPart = (str: string, unit: Unit) => {
+export const stringToArrayPart = (str: string, unit: Unit, options: ParseOptions) => {
   const values = sort(
     dedup(
       fixSunday(
@@ -60,9 +61,9 @@ export const stringToArrayPart = (str: string, unit: Unit) => {
               if (left === "*") {
                 parsedValues = range(unit.min, unit.max);
               } else {
-                parsedValues = parseRange(left, str, unit);
+                parsedValues = parseRange(left, str, unit, options);
               }
-              const step = parseStep(right, unit);
+              const step = parseStep(right, unit, options);
               return applyInterval(parsedValues, step);
             })
         ),
@@ -195,19 +196,20 @@ const getError = (error: string, unit: Unit) =>
  * @param rangeString The range string
  * @param context The operation context string
  * @param unit The unit for the part
+ * @param options Parse options
  * @return The resulting array
  */
-const parseRange = (rangeString: string, context: string, unit: Unit) => {
+const parseRange = (rangeString: string, context: string, unit: Unit, options: ParseOptions) => {
   const subparts = rangeString.split("-");
   if (subparts.length === 1) {
-    const value = parseNumber(unit, subparts[0]);
+    const value = parseNumber(unit, subparts[0], options);
     if (value === undefined) {
       throw getError(`Invalid value "${context}"`, unit);
     }
     return [value];
   } else if (subparts.length === 2) {
-    const minValue = parseNumber(unit, subparts[0]);
-    const maxValue = parseNumber(unit, subparts[1]);
+    const minValue = parseNumber(unit, subparts[0], options);
+    const maxValue = parseNumber(unit, subparts[1], options);
     if (minValue === undefined || maxValue === undefined) {
       throw getError(`Invalid value "${context}"`, unit);
     }
@@ -228,11 +230,12 @@ const parseRange = (rangeString: string, context: string, unit: Unit) => {
  *
  * @param step The step string
  * @param unit The unit for the part
+ * @param options Parse options
  * @return The step value
  */
-const parseStep = (step: string, unit: Unit) => {
+const parseStep = (step: string, unit: Unit, options: ParseOptions) => {
   if (step !== undefined) {
-    const parsedStep = parseNumber(unit, step);
+    const parsedStep = parseNumber(unit, step, options);
     if (parsedStep === undefined) {
       throw getError(`Invalid interval step value "${step}"`, unit);
     }

--- a/src/part.ts
+++ b/src/part.ts
@@ -196,6 +196,14 @@ const getError = (error: string, unit: Unit) =>
  * @return The resulting array
  */
 const parseRange = (rangeString: string, context: string, unit: Unit) => {
+  if (unit.name === 'day' && rangeString.startsWith('-')) {
+    // Negative number are allowed for days
+    const value = parseNumber(rangeString);
+    if (value === undefined) {
+      throw getError(`Invalid value "${context}"`, unit);
+    }
+    return [value];
+  }
   const subparts = rangeString.split("-");
   if (subparts.length === 1) {
     const value = parseNumber(subparts[0]);
@@ -299,8 +307,12 @@ const replaceAlternatives = (str: string, unit: Unit) => {
  * @param unit The unit for the part
  */
 const assertInRange = (values: number[], unit: Unit) => {
-  const first = values[0];
-  const last = values[values.length - 1];
+  let first = values[0];
+  let last = values[values.length - 1];
+  if (unit.name === 'day') {
+    first = Math.abs(first);
+    last = Math.abs(last);
+  }
   if (first < unit.min) {
     throw getError(`Value "${first}" out of range`, unit);
   } else if (last > unit.max) {

--- a/src/part.ts
+++ b/src/part.ts
@@ -47,7 +47,7 @@ export const stringToArrayPart = (str: string, unit: Unit) => {
     dedup(
       fixSunday(
         flatten(
-          str
+          replaceAlternatives(str, unit)
             .split(",")
             .map((value: string) => {
               const valueParts = value.split("/");
@@ -171,12 +171,7 @@ const formatValue = (value: number, unit: Unit, options: Options) => {
     (options.outputMonthNames && unit.name === "month")
   ) {
     if (unit.alt) {
-      const altValue = Array.from(unit.alt.entries())
-        .find(([, altValue]) => altValue === value)
-        ?.[0];
-      if (altValue) {
-        return altValue;
-      }
+      return unit.alt[value - unit.min];
     }
   }
   return value;
@@ -232,6 +227,23 @@ const parseRange = (rangeString: string, context: string, unit: Unit) => {
   } else {
     throw getError(`Invalid value "${rangeString}"`, unit);
   }
+};
+
+/**
+ * Replaces the alternative representations of numbers in a string
+ *
+ * @param str The string to process
+ * @param unit The unit for the part
+ * @return The resulting string
+ */
+const replaceAlternatives = (str: string, unit: Unit) => {
+  if (unit.alt) {
+    str = str.toUpperCase();
+    for (let i = 0; i < unit.alt.length; i++) {
+      str = str.replace(unit.alt[i], String(i + unit.min));
+    }
+  }
+  return str;
 };
 
 /**

--- a/src/part.ts
+++ b/src/part.ts
@@ -115,6 +115,8 @@ const toString = (values: number[], unit: Unit, options: Options) => {
     } else {
       retval = "*";
     }
+  } else if (unit.name === 'day' && values.length === 1 && values[0] === -1) {
+    retval = 'L';
   } else {
     const step = getStep(values);
     if (step && isInterval(values, step)) {
@@ -196,14 +198,6 @@ const getError = (error: string, unit: Unit) =>
  * @return The resulting array
  */
 const parseRange = (rangeString: string, context: string, unit: Unit) => {
-  if (unit.name === 'day' && rangeString.startsWith('-')) {
-    // Negative number are allowed for days
-    const value = parseNumber(unit, rangeString);
-    if (value === undefined) {
-      throw getError(`Invalid value "${context}"`, unit);
-    }
-    return [value];
-  }
   const subparts = rangeString.split("-");
   if (subparts.length === 1) {
     const value = parseNumber(unit, subparts[0]);
@@ -227,23 +221,6 @@ const parseRange = (rangeString: string, context: string, unit: Unit) => {
   } else {
     throw getError(`Invalid value "${rangeString}"`, unit);
   }
-};
-
-/**
- * Replaces the alternative representations of numbers in a string
- *
- * @param str The string to process
- * @param unit The unit for the part
- * @return The resulting string
- */
-const replaceAlternatives = (str: string, unit: Unit) => {
-  if (unit.alt) {
-    str = str.toUpperCase();
-    for (let i = 0; i < unit.alt.length; i++) {
-      str = str.replace(unit.alt[i], String(i + unit.min));
-    }
-  }
-  return str;
 };
 
 /**
@@ -301,6 +278,23 @@ const fixSunday = (values: number[], unit: Unit) => {
 };
 
 /**
+ * Replaces the alternative representations of numbers in a string
+ *
+ * @param str The string to process
+ * @param unit The unit for the part
+ * @return The resulting string
+ */
+const replaceAlternatives = (str: string, unit: Unit) => {
+  if (unit.alt) {
+    str = str.toUpperCase();
+    for (let i = 0; i < unit.alt.length; i++) {
+      str = str.replace(unit.alt[i], String(i + unit.min));
+    }
+  }
+  return str;
+};
+
+/**
  * Asserts that all `values` are in range for `unit`
  *
  * @param values The values to test
@@ -309,7 +303,7 @@ const fixSunday = (values: number[], unit: Unit) => {
 const assertInRange = (values: number[], unit: Unit) => {
   let first = values[0];
   let last = values[values.length - 1];
-  if (unit.name === 'day') {
+  if (unit.name === 'day' && first === -1 && last === -1) {
     first = Math.abs(first);
     last = Math.abs(last);
   }

--- a/src/schedule.ts
+++ b/src/schedule.ts
@@ -157,7 +157,7 @@ const shiftDay = (
 ): [DateTime, boolean] => {
   const currentMonth = date.month;
   while (
-    arr[2].indexOf(date.day) === -1 ||
+    (arr[2].indexOf(date.day) === -1 && arr[2].indexOf(date.day - date.endOf('month').day - 1) === -1) ||
     // luxon uses 1-7 for weekdays, but we use 0-6
     arr[4].indexOf(date.weekday === 7 ? 0 : date.weekday) === -1
   ) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@ export type Unit = {
   name: 'minute' | 'hour' | 'day' | 'month' | 'weekday',
   min: number;
   max: number;
-  alt?: ReadonlyArray<string>;
+  alt?: Map<string, number>;
 }
 
 export type Options = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,3 +10,7 @@ export type Options = {
   outputWeekdayNames: boolean;
   outputMonthNames: boolean;
 }
+
+export type ParseOptions = {
+  enableLastDayOfMonth: boolean;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@ export type Unit = {
   name: 'minute' | 'hour' | 'day' | 'month' | 'weekday',
   min: number;
   max: number;
-  alt?: Map<string, number>;
+  alt?: ReadonlyArray<string>;
 }
 
 export type Options = {

--- a/src/units.ts
+++ b/src/units.ts
@@ -14,7 +14,10 @@ export const units : ReadonlyArray<Unit> = Object.freeze([
   {
     name: 'day',
     min: 1,
-    max: 31
+    max: 31,
+    alt: new Map([
+      ['L', -1]
+    ])
   },
   {
     name: 'month',

--- a/src/units.ts
+++ b/src/units.ts
@@ -20,16 +20,33 @@ export const units : ReadonlyArray<Unit> = Object.freeze([
     name: 'month',
     min: 1,
     max: 12,
-    alt: [
-      'JAN', 'FEB', 'MAR', 'APR',
-      'MAY', 'JUN', 'JUL', 'AUG',
-      'SEP', 'OCT', 'NOV', 'DEC'
-    ]
+    alt: new Map([
+      ['JAN', 1],
+      ['FEB', 2],
+      ['MAR', 3],
+      ['APR', 4],
+      ['MAY', 5],
+      ['JUN', 6],
+      ['JUL', 7],
+      ['AUG', 8],
+      ['SEP', 9],
+      ['OCT', 10],
+      ['NOV', 11],
+      ['DEC', 12]
+    ])
   },
   {
     name: 'weekday',
     min: 0,
     max: 6,
-    alt: ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT']
+    alt: new Map([
+      ['SUN', 0],
+      ['MON', 1],
+      ['TUE', 2],
+      ['WED', 3],
+      ['THU', 4],
+      ['FRI', 5],
+      ['SAT', 6]
+    ])
   }
 ]);

--- a/src/units.ts
+++ b/src/units.ts
@@ -14,42 +14,22 @@ export const units : ReadonlyArray<Unit> = Object.freeze([
   {
     name: 'day',
     min: 1,
-    max: 31,
-    alt: new Map([
-      ['L', -1]
-    ])
+    max: 31
   },
   {
     name: 'month',
     min: 1,
     max: 12,
-    alt: new Map([
-      ['JAN', 1],
-      ['FEB', 2],
-      ['MAR', 3],
-      ['APR', 4],
-      ['MAY', 5],
-      ['JUN', 6],
-      ['JUL', 7],
-      ['AUG', 8],
-      ['SEP', 9],
-      ['OCT', 10],
-      ['NOV', 11],
-      ['DEC', 12]
-    ])
+    alt: [
+      'JAN', 'FEB', 'MAR', 'APR',
+      'MAY', 'JUN', 'JUL', 'AUG',
+      'SEP', 'OCT', 'NOV', 'DEC'
+    ]
   },
   {
     name: 'weekday',
     min: 0,
     max: 6,
-    alt: new Map([
-      ['SUN', 0],
-      ['MON', 1],
-      ['TUE', 2],
-      ['WED', 3],
-      ['THU', 4],
-      ['FRI', 5],
-      ['SAT', 6]
-    ])
+    alt: ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT']
   }
 ]);

--- a/src/util.ts
+++ b/src/util.ts
@@ -15,7 +15,7 @@ export const parseNumber = (unit: Unit, value: unknown) => {
 
   if (typeof value === "string") {
     const str: string = value.trim();
-    if (/^-?\d+$/.test(str)) {
+    if (/^\d+$/.test(str)) {
       const num = Number(str);
       if (!isNaN(num) && isFinite(num)) {
         return num;

--- a/src/util.ts
+++ b/src/util.ts
@@ -9,11 +9,11 @@ import {Unit} from "./types.js";
  * @returns The parsed integer or `undefined`
  */
 export const parseNumber = (unit: Unit, value: unknown) => {
-  if (typeof value === "string") {
-    if (unit.alt && unit.alt.has(value.toUpperCase())) {
-      return unit.alt.get(value.toUpperCase());
-    }
+  if (unit.name === 'day' && value === 'L') {
+    return -1;
+  }
 
+  if (typeof value === "string") {
     const str: string = value.trim();
     if (/^-?\d+$/.test(str)) {
       const num = Number(str);

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,12 +1,19 @@
+import {Unit} from "./types.js";
+
 /**
  * Parses a value as an integer or returns `undefined`
  * if the value could not be parsed a `number`
  *
  * @param value The integer `number` to parse
+ * @param unit The unit
  * @returns The parsed integer or `undefined`
  */
-export const parseNumber = (value: unknown) => {
+export const parseNumber = (unit: Unit, value: unknown) => {
   if (typeof value === "string") {
+    if (unit.alt && unit.alt.has(value.toUpperCase())) {
+      return unit.alt.get(value.toUpperCase());
+    }
+
     const str: string = value.trim();
     if (/^-?\d+$/.test(str)) {
       const num = Number(str);

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,4 @@
-import {Unit} from "./types.js";
+import { ParseOptions, Unit } from "./types.js";
 
 /**
  * Parses a value as an integer or returns `undefined`
@@ -6,10 +6,11 @@ import {Unit} from "./types.js";
  *
  * @param value The integer `number` to parse
  * @param unit The unit
+ * @param options Parse options
  * @returns The parsed integer or `undefined`
  */
-export const parseNumber = (unit: Unit, value: unknown) => {
-  if (unit.name === 'day' && value === 'L') {
+export const parseNumber = (unit: Unit, value: unknown, options: ParseOptions) => {
+  if (options?.enableLastDayOfMonth === true && unit.name === 'day' && value === 'L') {
     return -1;
   }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -8,7 +8,7 @@
 export const parseNumber = (value: unknown) => {
   if (typeof value === "string") {
     const str: string = value.trim();
-    if (/^\d+$/.test(str)) {
+    if (/^-?\d+$/.test(str)) {
       const num = Number(str);
       if (!isNaN(num) && isFinite(num)) {
         return num;

--- a/test/cron.invalid.array.ts
+++ b/test/cron.invalid.array.ts
@@ -34,6 +34,10 @@ const invalidCron = [
     array: [[-2], [1], [1], [1], [1]],
     error: 'Value "-2" out of range for minute',
   },
+  {
+    array: [[1], [1], [-2], [1], [1]],
+    error: 'Value "-2" out of range for day',
+  },
 ];
 
 describe("Should throw on invalid cron array", function () {

--- a/test/cron.valid.array.ts
+++ b/test/cron.valid.array.ts
@@ -14,6 +14,10 @@ const validCron = [
     in: [[0], [1], [1], [5], [0, 2, 4, 6]],
     out: "0 1 1 5 */2",
   },
+  {
+    in: [[0], [1], [-1], [5], [0, 2, 4, 6]],
+    out: "0 1 L 5 */2",
+  },
 ];
 
 describe("Should parse valid cron array", function () {

--- a/test/cron.valid.string.ts
+++ b/test/cron.valid.string.ts
@@ -54,6 +54,10 @@ const validCron = [
     in: "* 2-6/2,19-23/2 * * *",
     out: "* 2,4,6,19,21,23 * * *",
   },
+  {
+    in: "* 2-6/2,19-23/2 L * *",
+    out: "* 2,4,6,19,21,23 L * *",
+  },
 ];
 
 describe("Should parse valid cron string", function () {

--- a/test/range.invalid.ts
+++ b/test/range.invalid.ts
@@ -58,7 +58,7 @@ describe("Should throw on invalid range string", function () {
   invalidRanges.forEach(function (invalidRange) {
     it(invalidRange.input, function () {
       expect(() =>
-        stringToArrayPart(invalidRange.input, invalidRange.unit)
+        stringToArrayPart(invalidRange.input, invalidRange.unit, {enableLastDayOfMonth: true})
       ).to.throw(invalidRange.error);
     });
   });

--- a/test/range.valid.ts
+++ b/test/range.valid.ts
@@ -98,7 +98,7 @@ const validRanges = [
 ];
 describe("Should parse valid string", function () {
   validRanges.forEach(function (validRange) {
-    const range = stringToArrayPart(validRange.input, validRange.unit);
+    const range = stringToArrayPart(validRange.input, validRange.unit, {enableLastDayOfMonth: true});
     it(validRange.input + " as array", function () {
       expect(range).to.eql(validRange.arr);
     });

--- a/test/schedule.invalid.ts
+++ b/test/schedule.invalid.ts
@@ -28,4 +28,10 @@ describe("Should throw", function () {
       "Invalid timezone provided"
     );
   });
+
+  it("enableLastDayOfMonth disabled", function () {
+    expect(() => stringToArray("* * L * *", {enableLastDayOfMonth: false})).to.throw(
+      "Invalid value \"L\" for day"
+    );
+  });
 });

--- a/test/schedule.valid.ts
+++ b/test/schedule.valid.ts
@@ -100,6 +100,41 @@ const schedules = [
     next: "2013-02-11T06:00:00.000Z",
     timezone: "utc",
   },
+  {
+    schedule: "55 23 -1 * *",
+    now: "2024-02-08T09:32:15.000Z",
+    prev: "2024-01-31T23:55:00.000Z",
+    next: "2024-02-29T23:55:00.000Z",
+    timezone: "utc",
+  },
+  {
+    schedule: "55 23 -1 * *",
+    now: "2023-02-08T09:32:15.000Z",
+    prev: "2023-01-31T23:55:00.000Z",
+    next: "2023-02-28T23:55:00.000Z",
+    timezone: "utc",
+  },
+  {
+    schedule: "55 23 -1 * *",
+    now: "2023-01-08T09:32:15.000Z",
+    prev: "2022-12-31T23:55:00.000Z",
+    next: "2023-01-31T23:55:00.000Z",
+    timezone: "utc",
+  },
+  {
+    schedule: "55 23 -1 * *",
+    now: "2023-04-30T09:32:15.000Z",
+    prev: "2023-03-31T23:55:00.000Z",
+    next: "2023-04-30T23:55:00.000Z",
+    timezone: "utc",
+  },
+  {
+    schedule: "55 23 -2 * *",
+    now: "2023-04-30T09:32:15.000Z",
+    prev: "2023-04-29T23:55:00.000Z",
+    next: "2023-05-30T23:55:00.000Z",
+    timezone: "utc",
+  }
 ];
 describe("Should output execution time for valid schedule", function () {
   schedules.forEach(function (s) {

--- a/test/schedule.valid.ts
+++ b/test/schedule.valid.ts
@@ -100,42 +100,6 @@ const schedules = [
     next: "2013-02-11T06:00:00.000Z",
     timezone: "utc",
   },
-  // Days from the end of the mouth (negative)
-  {
-    schedule: "55 23 -1 * *",
-    now: "2024-02-08T09:32:15.000Z",
-    prev: "2024-01-31T23:55:00.000Z",
-    next: "2024-02-29T23:55:00.000Z",
-    timezone: "utc",
-  },
-  {
-    schedule: "55 23 -1 * *",
-    now: "2023-02-08T09:32:15.000Z",
-    prev: "2023-01-31T23:55:00.000Z",
-    next: "2023-02-28T23:55:00.000Z",
-    timezone: "utc",
-  },
-  {
-    schedule: "55 23 -1 * *",
-    now: "2023-01-08T09:32:15.000Z",
-    prev: "2022-12-31T23:55:00.000Z",
-    next: "2023-01-31T23:55:00.000Z",
-    timezone: "utc",
-  },
-  {
-    schedule: "55 23 -1 * *",
-    now: "2023-04-30T09:32:15.000Z",
-    prev: "2023-03-31T23:55:00.000Z",
-    next: "2023-04-30T23:55:00.000Z",
-    timezone: "utc",
-  },
-  {
-    schedule: "55 23 -2 * *",
-    now: "2023-04-30T09:32:15.000Z",
-    prev: "2023-04-29T23:55:00.000Z",
-    next: "2023-05-30T23:55:00.000Z",
-    timezone: "utc",
-  },
   // Last day of month alias
   {
     schedule: "55 23 L * *",

--- a/test/schedule.valid.ts
+++ b/test/schedule.valid.ts
@@ -100,6 +100,7 @@ const schedules = [
     next: "2013-02-11T06:00:00.000Z",
     timezone: "utc",
   },
+  // Days from the end of the mouth (negative)
   {
     schedule: "55 23 -1 * *",
     now: "2024-02-08T09:32:15.000Z",
@@ -133,6 +134,14 @@ const schedules = [
     now: "2023-04-30T09:32:15.000Z",
     prev: "2023-04-29T23:55:00.000Z",
     next: "2023-05-30T23:55:00.000Z",
+    timezone: "utc",
+  },
+  // Last day of month alias
+  {
+    schedule: "55 23 L * *",
+    now: "2024-02-08T09:32:15.000Z",
+    prev: "2024-01-31T23:55:00.000Z",
+    next: "2024-02-29T23:55:00.000Z",
     timezone: "utc",
   }
 ];

--- a/test/util.number.ts
+++ b/test/util.number.ts
@@ -4,8 +4,6 @@ import { units } from "../src/units.js";
 import {Unit} from "../src/types.js";
 
 const MINUTE_UNIT = units.find(unit => unit.name === 'minute') as Unit;
-const WEEKDAY_UNIT = units.find(unit => unit.name === 'weekday') as Unit;
-const MONTH_UNIT = units.find(unit => unit.name === 'month') as Unit;
 const DAY_UNIT = units.find(unit => unit.name === 'day') as Unit;
 
 describe("parseNumber", function () {
@@ -50,19 +48,6 @@ describe("parseNumber", function () {
     it(`should not parse '${input}'`, function () {
       expect(parseNumber(MINUTE_UNIT, input)).to.equal(undefined);
     });
-  });
-
-  it(`Weekday names`, function () {
-    expect(parseNumber(WEEKDAY_UNIT, 'SUN')).to.equal(0);
-    expect(parseNumber(WEEKDAY_UNIT, 'MON')).to.equal(1);
-    expect(parseNumber(WEEKDAY_UNIT, 'SAT')).to.equal(6);
-    expect(parseNumber(WEEKDAY_UNIT, 'NONE')).to.equal(undefined);
-  });
-
-  it(`Months names`, function () {
-    expect(parseNumber(MONTH_UNIT, 'JAN')).to.equal(1);
-    expect(parseNumber(MONTH_UNIT, 'DEC')).to.equal(12);
-    expect(parseNumber(MONTH_UNIT, 'NONE')).to.equal(undefined);
   });
 
   it(`End of mount alt name`, function () {

--- a/test/util.number.ts
+++ b/test/util.number.ts
@@ -1,5 +1,12 @@
 import { parseNumber } from "../src/util.js";
 import { expect } from "chai";
+import { units } from "../src/units.js";
+import {Unit} from "../src/types.js";
+
+const MINUTE_UNIT = units.find(unit => unit.name === 'minute') as Unit;
+const WEEKDAY_UNIT = units.find(unit => unit.name === 'weekday') as Unit;
+const MONTH_UNIT = units.find(unit => unit.name === 'month') as Unit;
+
 describe("parseNumber", function () {
   [
     { input: 0.0, output: 0 },
@@ -12,7 +19,7 @@ describe("parseNumber", function () {
     { input: "  000123  ", output: 123 },
   ].forEach(({ input, output }) => {
     it(`should parse '${input}'`, function () {
-      expect(parseNumber(input)).to.equal(output);
+      expect(parseNumber(MINUTE_UNIT, input)).to.equal(output);
     });
   });
   [
@@ -40,7 +47,20 @@ describe("parseNumber", function () {
     {},
   ].forEach((input) => {
     it(`should not parse '${input}'`, function () {
-      expect(parseNumber(input)).to.equal(undefined);
+      expect(parseNumber(MINUTE_UNIT, input)).to.equal(undefined);
     });
+  });
+
+  it(`Weekday names`, function () {
+    expect(parseNumber(WEEKDAY_UNIT, 'SUN')).to.equal(0);
+    expect(parseNumber(WEEKDAY_UNIT, 'MON')).to.equal(1);
+    expect(parseNumber(WEEKDAY_UNIT, 'SAT')).to.equal(6);
+    expect(parseNumber(WEEKDAY_UNIT, 'NONE')).to.equal(undefined);
+  });
+
+  it(`Months names`, function () {
+    expect(parseNumber(MONTH_UNIT, 'JAN')).to.equal(1);
+    expect(parseNumber(MONTH_UNIT, 'DEC')).to.equal(12);
+    expect(parseNumber(MONTH_UNIT, 'NONE')).to.equal(undefined);
   });
 });

--- a/test/util.number.ts
+++ b/test/util.number.ts
@@ -19,7 +19,6 @@ describe("parseNumber", function () {
     "",
     " ",
     "+123",
-    "-123",
     "1.2",
     "1,2",
     "12e5",

--- a/test/util.number.ts
+++ b/test/util.number.ts
@@ -6,6 +6,7 @@ import {Unit} from "../src/types.js";
 const MINUTE_UNIT = units.find(unit => unit.name === 'minute') as Unit;
 const WEEKDAY_UNIT = units.find(unit => unit.name === 'weekday') as Unit;
 const MONTH_UNIT = units.find(unit => unit.name === 'month') as Unit;
+const DAY_UNIT = units.find(unit => unit.name === 'day') as Unit;
 
 describe("parseNumber", function () {
   [
@@ -62,5 +63,12 @@ describe("parseNumber", function () {
     expect(parseNumber(MONTH_UNIT, 'JAN')).to.equal(1);
     expect(parseNumber(MONTH_UNIT, 'DEC')).to.equal(12);
     expect(parseNumber(MONTH_UNIT, 'NONE')).to.equal(undefined);
+  });
+
+  it(`End of mount alt name`, function () {
+    expect(parseNumber(DAY_UNIT, 'L')).to.equal(-1);
+    expect(parseNumber(DAY_UNIT, 1)).to.equal(1);
+    expect(parseNumber(DAY_UNIT, -1)).to.equal(-1);
+    expect(parseNumber(DAY_UNIT, 'NONE')).to.equal(undefined);
   });
 });

--- a/test/util.number.ts
+++ b/test/util.number.ts
@@ -51,7 +51,7 @@ describe("parseNumber", function () {
     });
   });
 
-  it(`End of mount alt name`, function () {
+  it(`End of month alt name`, function () {
     expect(parseNumber(DAY_UNIT, 'L')).to.equal(-1);
     expect(parseNumber(DAY_UNIT, 1)).to.equal(1);
     expect(parseNumber(DAY_UNIT, -1)).to.equal(-1);

--- a/test/util.number.ts
+++ b/test/util.number.ts
@@ -25,6 +25,7 @@ describe("parseNumber", function () {
     "",
     " ",
     "+123",
+    "-123",
     "1.2",
     "1,2",
     "12e5",

--- a/test/util.number.ts
+++ b/test/util.number.ts
@@ -1,7 +1,11 @@
 import { parseNumber } from "../src/util.js";
 import { expect } from "chai";
 import { units } from "../src/units.js";
-import {Unit} from "../src/types.js";
+import { ParseOptions, Unit } from "../src/types.js";
+
+const parseOptions: ParseOptions = {
+  enableLastDayOfMonth: true
+};
 
 const MINUTE_UNIT = units.find(unit => unit.name === 'minute') as Unit;
 const DAY_UNIT = units.find(unit => unit.name === 'day') as Unit;
@@ -18,7 +22,7 @@ describe("parseNumber", function () {
     { input: "  000123  ", output: 123 },
   ].forEach(({ input, output }) => {
     it(`should parse '${input}'`, function () {
-      expect(parseNumber(MINUTE_UNIT, input)).to.equal(output);
+      expect(parseNumber(MINUTE_UNIT, input, parseOptions)).to.equal(output);
     });
   });
   [
@@ -47,14 +51,15 @@ describe("parseNumber", function () {
     {},
   ].forEach((input) => {
     it(`should not parse '${input}'`, function () {
-      expect(parseNumber(MINUTE_UNIT, input)).to.equal(undefined);
+      expect(parseNumber(MINUTE_UNIT, input, parseOptions)).to.equal(undefined);
     });
   });
 
   it(`End of month alt name`, function () {
-    expect(parseNumber(DAY_UNIT, 'L')).to.equal(-1);
-    expect(parseNumber(DAY_UNIT, 1)).to.equal(1);
-    expect(parseNumber(DAY_UNIT, -1)).to.equal(-1);
-    expect(parseNumber(DAY_UNIT, 'NONE')).to.equal(undefined);
+    expect(parseNumber(DAY_UNIT, 'L', {enableLastDayOfMonth: false})).to.equal(undefined);
+    expect(parseNumber(DAY_UNIT, 'L', {enableLastDayOfMonth: true})).to.equal(-1);
+    expect(parseNumber(DAY_UNIT, 1, parseOptions)).to.equal(1);
+    expect(parseNumber(DAY_UNIT, -1, parseOptions)).to.equal(-1);
+    expect(parseNumber(DAY_UNIT, 'NONE', parseOptions)).to.equal(undefined);
   });
 });


### PR DESCRIPTION
## New feature
This PR adds support for :
 - `L` in the day field, to select the last day of the month
 - negative number in the day field, to select a day indexed from the end of the month

`L` is just an alias for `-1`

`L` is used for end of month on many cron implementation (source: https://stackoverflow.com/questions/6139189/cron-job-to-run-on-the-last-day-of-the-month).

There are no bullet-proof ways to declare "end of month" with the basic cron feature (none that supports leap years).

## Internal changes
To allow for the `L` alias, I transformed the `alt` `Array` into a `Map`. 